### PR TITLE
Add Type to InteractionDataOption

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandInteractionDataOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandInteractionDataOption.cs
@@ -17,6 +17,11 @@ namespace Discord
         string Name { get; }
 
         /// <summary>
+        ///     The type of this <see cref="IApplicationCommandInteractionDataOption"/>.
+        /// </summary>
+        public ApplicationCommandOptionType Type { get; }
+
+        /// <summary>
         ///     The value of the pair.
         ///     <note>
         ///         This objects type can be any one of the option types in <see cref="ApplicationCommandOptionType"/>

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs
@@ -12,6 +12,9 @@ namespace Discord.API
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        [JsonProperty("type")]
+        public ApplicationCommandOptionType Type { get; set; }
+
         [JsonProperty("value")]
         public Optional<object> Value { get; set; }
 

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteractionDataOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteractionDataOption.cs
@@ -17,6 +17,9 @@ namespace Discord.WebSocket
         public string Name { get; private set; }
 
         /// <inheritdoc/>
+        public ApplicationCommandOptionType Type { get; private set; }
+
+        /// <inheritdoc/>
         public object Value { get; private set; }
 
         /// <summary>
@@ -31,6 +34,7 @@ namespace Discord.WebSocket
         internal SocketInteractionDataOption(Model model, DiscordSocketClient discord, ulong guild)
         {
             this.Name = model.Name;
+            this.Type = model.Type;
             this.Value = model.Value.IsSpecified ? model.Value.Value : null;
             this.discord = discord;
             this.guild = guild;


### PR DESCRIPTION
This PR adds the `ApplicationCommandOptionType` to the `InteractionDataOption` as defined in [SlashCommands#ApplicationCommandInteractionDataOption](https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondataoption)