### PR TITLE
Options is an optional field

### DIFF
--- a/src/Discord.Net.WebSocket/API/Gateway/ApplicationCommandCreatedUpdatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ApplicationCommandCreatedUpdatedEvent.cs
@@ -25,6 +25,6 @@ namespace Discord.API.Gateway
         public ulong GuildId { get; set; }
 
         [JsonProperty("options")]
-        public List<Discord.API.ApplicationCommandOption> Options { get; set; }
+        public Optional<List<Discord.API.ApplicationCommandOption>> Options { get; set; }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketApplicationCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketApplicationCommand.cs
@@ -56,8 +56,8 @@ namespace Discord.WebSocket
             this.Name = model.Name;
             this.GuildId = model.GuildId;
 
-            this.Options = model.Options.Any()
-                ? model.Options.Select(x => SocketApplicationCommandOption.Create(x)).ToImmutableArray()
+            this.Options = model.Options.IsSpecified
+                ? model.Options.Value.Select(x => SocketApplicationCommandOption.Create(x)).ToImmutableArray()
                 : new ImmutableArray<SocketApplicationCommandOption>();
         }
 


### PR DESCRIPTION
This PR makes the `Options` field `Optional` in the `ApplicationCommandCreatedUpdatedEvent` as defined in [SlashCommands#ApplicationCommand](https://discord.com/developers/docs/interactions/slash-commands#applicationcommand).

This also fixes an exception that can occur in the `SocketApplicationCommand` due to the `Options` potentially being null.